### PR TITLE
Make onNew(notification:) async

### DIFF
--- a/Sources/Parcelvoy/InAppDelegate.swift
+++ b/Sources/Parcelvoy/InAppDelegate.swift
@@ -7,7 +7,7 @@ public enum InAppDisplayState {
 public protocol InAppDelegate: AnyObject {
     var autoShow: Bool { get }
     var useDarkMode: Bool { get }
-    func onNew(notification: ParcelvoyNotification) -> InAppDisplayState
+    func onNew(notification: ParcelvoyNotification) async -> InAppDisplayState
     func didDisplay(notification: ParcelvoyNotification)
     func handle(action: InAppAction, context: [String: Any], notification: ParcelvoyNotification)
     func onError(error: Error)
@@ -16,7 +16,7 @@ public protocol InAppDelegate: AnyObject {
 extension InAppDelegate {
     public var autoShow: Bool { true }
     public var useDarkMode: Bool { false }
-    public func onNew(notification: ParcelvoyNotification) -> InAppDisplayState { .show }
+    public func onNew(notification: ParcelvoyNotification) async -> InAppDisplayState { .show }
     public func didDisplay(notification: ParcelvoyNotification) {}
     public func onError(error: Error) {}
 }

--- a/Sources/Parcelvoy/Parcelvoy.swift
+++ b/Sources/Parcelvoy/Parcelvoy.swift
@@ -222,7 +222,7 @@ public class Parcelvoy {
             // Run through all notifications to check if they should
             // be displayed or not
             for notification in notifications.results {
-                if let response = self.inAppDelegate?.onNew(notification: notification) {
+                if let response = await self.inAppDelegate?.onNew(notification: notification) {
                     switch response {
                     case .show: await self.show(notification: notification)
                     case .consume: await self.consume(notification: notification)


### PR DESCRIPTION
This allows for accessing methods/properties that are bound to the main actor when determining whether or not to show a notification.